### PR TITLE
Add initial project (OSK-1)

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -1,0 +1,33 @@
+name: .NET Test Automation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: [ '8.0.x' ]
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+    - name: Restore dependencies
+      run: >-
+        dotnet restore ./src/${{ github.event.repository.name }}.sln
+    - name: Build
+      run: dotnet build --no-restore ./src/${{ github.event.repository.name }}.sln
+    - name: Test
+      run: dotnet test --no-build --verbosity normal ./src/${{ github.event.repository.name }}.sln

--- a/.github/workflows/issueLinker-workflow.yml
+++ b/.github/workflows/issueLinker-workflow.yml
@@ -1,0 +1,23 @@
+name: Attach Issue Link
+
+on:
+  pull_request:
+    branches: [ main ]
+    
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: the-wright-jamie/update-pr-info-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        head-branch-regex: '\d+'
+        body-template: |
+          Fixes #%headbranch%
+        body-update-action: 'suffix'
+        body-uppercase-head-match: false
+        lowercase-branch: false

--- a/.github/workflows/publish-packages-workflow.yml
+++ b/.github/workflows/publish-packages-workflow.yml
@@ -1,0 +1,29 @@
+name: Publish packages
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+permissions:
+  packages: write
+  contents: read
+    
+jobs:
+  publish-nuget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get the version
+        id: get_version
+        run: echo "PACKAGE_VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT" 
+      - uses: actions/setup-dotnet@v4.0.0
+        with:
+          dotnet-version: '8.0.x' # SDK Version to use.
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_TOKEN }}
+      - run: dotnet build --configuration Release ./src /p:Version=${{ steps.get_version.outputs.PACKAGE_VERSION }}
+      - name: Create the package
+        run: dotnet pack --configuration Release ./src -o . /p:Version=${{ steps.get_version.outputs.PACKAGE_VERSION }}
+      - name: Publish the package to Nuget
+        run: dotnet nuget push ./*.nupkg --api-key ${{ secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json

--- a/src/OSK.MessageBus.Abstractions/IMessageEventContext.cs
+++ b/src/OSK.MessageBus.Abstractions/IMessageEventContext.cs
@@ -1,0 +1,14 @@
+﻿using OSK.MessageBus.Events.Abstractions;
+using System;
+
+namespace OSK.MessageBus.Abstractions
+{
+    public interface IMessageEventContext
+    {
+        public IServiceProvider Services { get; }
+
+        public object RawMessage { get; }
+
+        public IMessageEvent Message { get; }
+    }
+}

--- a/src/OSK.MessageBus.Abstractions/IMessageEventContext`1.cs
+++ b/src/OSK.MessageBus.Abstractions/IMessageEventContext`1.cs
@@ -1,0 +1,10 @@
+﻿using OSK.MessageBus.Events.Abstractions;
+
+namespace OSK.MessageBus.Abstractions
+{
+    public interface IMessageEventContext<TMessage>: IMessageEventContext
+        where TMessage : IMessageEvent
+    {
+        new TMessage Message { get; }
+    }
+}

--- a/src/OSK.MessageBus.Abstractions/IMessageEventSink.cs
+++ b/src/OSK.MessageBus.Abstractions/IMessageEventSink.cs
@@ -1,0 +1,13 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using OSK.MessageBus.Events.Abstractions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus.Abstractions
+{
+    public interface IMessageEventSink
+    {
+        Task<IOutput> PublishAsync<TMessage>(TMessage messageEvent, MessagePublishOptions options, CancellationToken cancellationToken = default)
+            where TMessage : IMessageEvent;
+    }
+}

--- a/src/OSK.MessageBus.Abstractions/MessageEventSinkExtensions.cs
+++ b/src/OSK.MessageBus.Abstractions/MessageEventSinkExtensions.cs
@@ -1,0 +1,20 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using OSK.MessageBus.Events.Abstractions;
+using System;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace OSK.MessageBus.Abstractions
+{
+    public static class MessageEventSinkExtensions
+    {
+        public static Task<IOutput> PublishAsync<TMessage>(this IMessageEventSink eventSink, TMessage messageEvent, CancellationToken cancellationToken = default)
+            where TMessage : IMessageEvent => eventSink.PublishAsync(messageEvent, TimeSpan.Zero, cancellationToken);
+
+        public static Task<IOutput> PublishAsync<TMessage>(this IMessageEventSink eventSink, TMessage messageEvent, TimeSpan delayTimeSpan, CancellationToken cancellationToken = default)
+            where TMessage : IMessageEvent => eventSink.PublishAsync(messageEvent, new MessagePublishOptions()
+            {
+                DelayTimeSpan = delayTimeSpan
+            }, cancellationToken);
+    }
+}

--- a/src/OSK.MessageBus.Abstractions/MessagePublishOptions.cs
+++ b/src/OSK.MessageBus.Abstractions/MessagePublishOptions.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace OSK.MessageBus.Abstractions
+{
+    public class MessagePublishOptions
+    {
+        public TimeSpan DelayTimeSpan { get; set; }
+    }
+}

--- a/src/OSK.MessageBus.Abstractions/OSK.MessageBus.Abstractions.csproj
+++ b/src/OSK.MessageBus.Abstractions/OSK.MessageBus.Abstractions.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.MessageBus</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<Description>An abstraction layer for communicating across a variety of different message buses seamlessly and easily. Meant to allow easy integration between different message buses without causing drastic changes to the consumers.</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, Abstraction, Generic, Communication, Message, Bus, Architecture, Async, Event, Consistency, Network, Api</PackageTags>
+		<Authors>BlankDev117</Authors>
+		<Title>OSK.MessageBus.Abstractions</Title>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="OSK.Functions.Outputs.Logging.Abstractions" Version="1.5.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\OSK.MessageBus.Events.Abstractions\OSK.MessageBus.Events.Abstractions.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.MessageBus.Application/MessageBusApplicationService.cs
+++ b/src/OSK.MessageBus.Application/MessageBusApplicationService.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Extensions.Hosting;
+using OSK.MessageBus.Ports;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus.Application
+{
+    public class MessageBusApplicationService(IMessageEventReceiverManager manager,
+        IEnumerable<MessageBusReceiverConfigurationService> receiverConfigurators)
+        : IHostedService
+    {
+        #region Variables
+
+        private bool _configured;
+
+        #endregion
+
+        #region IHostedService
+
+        public virtual Task StartAsync(CancellationToken cancellationToken)
+        {
+            if (!_configured)
+            {
+                foreach (var configurator in receiverConfigurators)
+                {
+                    configurator.ConfigureManager(manager);
+                }
+                _configured = true;
+            }
+
+            return Task.Run(manager.Start);
+        }
+
+        public virtual Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.Run(manager.Stop);
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.MessageBus.Application/MessageBusReceiverConfigurationService.cs
+++ b/src/OSK.MessageBus.Application/MessageBusReceiverConfigurationService.cs
@@ -1,0 +1,9 @@
+﻿using OSK.MessageBus.Ports;
+
+namespace OSK.MessageBus.Application
+{
+    public abstract class MessageBusReceiverConfigurationService
+    {
+        public abstract void ConfigureManager(IMessageEventReceiverManager manager);
+    }
+}

--- a/src/OSK.MessageBus.Application/OSK.MessageBus.Application.csproj
+++ b/src/OSK.MessageBus.Application/OSK.MessageBus.Application.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<Nullable>enable</Nullable>
+		<LangVersion>12</LangVersion>
+		<RepositoryType>git</RepositoryType>
+		<Description>An application layer for communicating across a variety of different message buses seamlessly and easily. Meant to allow easy integration between different message buses without causing drastic changes to the consumers. Provides a hosted service and method of adding message receivers to a runtime manager.</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, Application, Communication, Message, Bus, Architecture, Async, Event, Consistency, Network, Api</PackageTags>
+		<Authors>BlankDev117</Authors>
+		<Title>OSK.MessageBus.Application</Title>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\OSK.MessageBus\OSK.MessageBus.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.MessageBus.Application/ServiceCollectionExtensions.cs
+++ b/src/OSK.MessageBus.Application/ServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace OSK.MessageBus.Application
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddHostedMessageBusManagement(this IServiceCollection services)
+        {
+            services.AddHostedService<MessageBusApplicationService>();
+
+            return services;
+        }
+    }
+}

--- a/src/OSK.MessageBus.Events.Abstractions/IMessageEvent.cs
+++ b/src/OSK.MessageBus.Events.Abstractions/IMessageEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace OSK.MessageBus.Events.Abstractions
+{
+    public interface IMessageEvent
+    {
+        public string TopicId { get; }
+    }
+}

--- a/src/OSK.MessageBus.Events.Abstractions/IMessageEvent`1.cs
+++ b/src/OSK.MessageBus.Events.Abstractions/IMessageEvent`1.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace OSK.MessageBus.Events.Abstractions
+{
+    public interface IMessageEvent<TId>: IMessageEvent
+        where TId : struct, IEquatable<TId>
+    {
+        public TId Id { get; }
+    }
+}

--- a/src/OSK.MessageBus.Events.Abstractions/ITenantedMessageEvent.cs
+++ b/src/OSK.MessageBus.Events.Abstractions/ITenantedMessageEvent.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace OSK.MessageBus.Events.Abstractions
+{
+    public interface ITenantedMessageEvent<TTenantId, TId>: IMessageEvent<TId>
+        where TTenantId : struct, IEquatable<TTenantId>
+        where TId : struct, IEquatable<TId>
+    {
+        TTenantId TenantId { get; } 
+    }
+}

--- a/src/OSK.MessageBus.Events.Abstractions/MessageEventBase.cs
+++ b/src/OSK.MessageBus.Events.Abstractions/MessageEventBase.cs
@@ -1,0 +1,7 @@
+﻿namespace OSK.MessageBus.Events.Abstractions
+{
+    public abstract class MessageEventBase: IMessageEvent
+    {
+        public string TopicId { get; set; }
+    }
+}

--- a/src/OSK.MessageBus.Events.Abstractions/MessageEventBase`1.cs
+++ b/src/OSK.MessageBus.Events.Abstractions/MessageEventBase`1.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace OSK.MessageBus.Events.Abstractions
+{
+    public abstract class MessageEventBase<TId>: MessageEventBase, IMessageEvent<TId>
+        where TId : struct, IEquatable<TId>
+    {
+        public TId Id { get; set; }
+    }
+}

--- a/src/OSK.MessageBus.Events.Abstractions/OSK.MessageBus.Events.Abstractions.csproj
+++ b/src/OSK.MessageBus.Events.Abstractions/OSK.MessageBus.Events.Abstractions.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<RepositoryType>git</RepositoryType>
+		<Description>A layer providing common event type abstractions for communicating across a variety of different message buses seamlessly and easily. Meant to allow easy integration between different message buses without causing drastic changes to the consumers. Provides a hosted service and method of adding message receivers to a runtime manager.</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, Abstractions, Application, Communication, Message, Bus, Architecture, Async, Event, Consistency, Network, Api</PackageTags>
+		<Authors>BlankDev117</Authors>
+		<Title>OSK.MessageBus.Events.Abstractions</Title>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
+</Project>

--- a/src/OSK.MessageBus.Events.Abstractions/TenantedMessageEventBase.cs
+++ b/src/OSK.MessageBus.Events.Abstractions/TenantedMessageEventBase.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace OSK.MessageBus.Events.Abstractions
+{
+    public abstract class TenantedMessageEventBase<TTenantId, TId>: MessageEventBase<TId>, ITenantedMessageEvent<TTenantId, TId>
+        where TTenantId: struct, IEquatable<TTenantId>
+        where TId: struct, IEquatable<TId>
+    {
+        public  TTenantId TenantId { get; set; }
+    }
+}

--- a/src/OSK.MessageBus.UnitTests/Helpers/TestEvent.cs
+++ b/src/OSK.MessageBus.UnitTests/Helpers/TestEvent.cs
@@ -1,0 +1,9 @@
+﻿using OSK.MessageBus.Events.Abstractions;
+
+namespace OSK.MessageBus.UnitTests.Helpers
+{
+    public class TestEvent : IMessageEvent
+    {
+        public string TopicId => throw new NotImplementedException();
+    }
+}

--- a/src/OSK.MessageBus.UnitTests/Helpers/TestEventSink.cs
+++ b/src/OSK.MessageBus.UnitTests/Helpers/TestEventSink.cs
@@ -1,0 +1,15 @@
+﻿using OSK.Functions.Outputs.Logging.Abstractions;
+using OSK.MessageBus.Ports;
+
+namespace OSK.MessageBus.UnitTests.Helpers
+{
+    public class TestEventSink : MessageEventSinkBase
+    {
+        public const string TestEventSinkSource = "Test";
+
+        public TestEventSink(IMessageEventPublisher publisher, IOutputFactory<MessageEventSinkBase> outputFactory) 
+            : base(publisher, outputFactory, TestEventSinkSource)
+        {
+        }
+    }
+}

--- a/src/OSK.MessageBus.UnitTests/Internal/Services/MessageEventReceiverManagerTests.cs
+++ b/src/OSK.MessageBus.UnitTests/Internal/Services/MessageEventReceiverManagerTests.cs
@@ -1,0 +1,189 @@
+﻿using Moq;
+using OSK.MessageBus.Internal.Services;
+using OSK.MessageBus.Ports;
+using Xunit;
+
+namespace OSK.MessageBus.RabbitMQ.UnitTests.Internal.Services
+{
+    public class MessageEventReceiverManagerTests
+    {
+        #region Variables
+
+        private readonly IMessageEventReceiverManager _manager;
+
+        #endregion
+
+        #region Constructors
+
+        public MessageEventReceiverManagerTests()
+        {
+            _manager = new MessageEventReceiverManager(Mock.Of<IServiceProvider>());
+        }
+
+        #endregion
+
+        #region AddConfigurator
+
+        [Fact]
+        public void AddConfigurator_NullAction_ThrowsArgumentNullException()
+        {
+            // Arrange/Act/Assert
+            Assert.Throws<ArgumentNullException>(() => _manager.AddConfigurator(null));
+        }
+
+        [Fact]
+        public void AddConfigurator_ValidAction_ReturnsSuccessfully()
+        {
+            // Arrange/Act/Assert
+            _manager.AddConfigurator(_ => { });
+        }
+
+        #endregion
+
+        #region AddEventReceiver
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public void AddEventReceiver_InvalidSubscriptionId_ThrowsArgumentException(string subscriptionId)
+        {
+            // Arrange/Act/Assert
+            Assert.Throws<ArgumentException>(() => _manager.AddEventReceiver(subscriptionId,
+                (_, _) => Mock.Of<IMessageEventReceiverBuilder>()));
+        }
+
+        [Fact]
+        public void AddEventReceiver_DuplicateSubscriptionId_ThrowsInvalidOperationException()
+        {
+            // Arrange/Act
+            _manager.AddEventReceiver("Abc", (_, _) => Mock.Of<IMessageEventReceiverBuilder>());
+
+            // Assert
+            Assert.Throws<InvalidOperationException>(() => 
+            _manager.AddEventReceiver("Abc", (_, _) => Mock.Of<IMessageEventReceiverBuilder>()));
+        }
+
+        #endregion
+
+        #region Start
+
+        [Fact]
+        public void Start_ConfiguresManager_RunsTwice_ConfiguresOnlyOnce()
+        {
+            // Arrange
+            var mockReceiver = new Mock<IMessageEventReceiver>();
+            var builder = new Mock<IMessageEventReceiverBuilder>();
+            builder.Setup(m => m.BuildReceiver(It.IsAny<string>()))
+                .Returns(mockReceiver.Object);
+
+            _manager.AddEventReceiver("Abc", (_, _) => builder.Object);
+
+            // Act
+            _manager.Start();
+            _manager.Start();
+
+            // Asseer
+            builder.Verify(m => m.BuildReceiver(It.IsAny<string>()), Times.Once);
+            mockReceiver.Verify(m => m.Start(), Times.Once);
+        }
+
+        #endregion
+
+        #region Stop
+
+        [Fact]
+        public void Stop_MultipleCalls_RunsOnce_MultipleReceiversStop_SomeThrowExceptions_StopsAllReceiversAndThrowsAggregateException()
+        {
+            // Arrange
+            var receiverA = new Mock<IMessageEventReceiver>();
+            var receiverB = new Mock<IMessageEventReceiver>();
+            var receiverC = new Mock<IMessageEventReceiver>();
+
+            receiverB.Setup(m => m.Dispose())
+                .Throws<InvalidOperationException>();
+
+            _manager.AddEventReceiver("A", (_, _) =>
+            {
+                var builder = new Mock<IMessageEventReceiverBuilder>();
+                builder.Setup(m => m.BuildReceiver(It.IsAny<string>()))
+                    .Returns(receiverA.Object);
+
+                return builder.Object;
+            });
+            _manager.AddEventReceiver("B", (_, _) =>
+            {
+                var builder = new Mock<IMessageEventReceiverBuilder>();
+                builder.Setup(m => m.BuildReceiver(It.IsAny<string>()))
+                    .Returns(receiverB.Object);
+
+                return builder.Object;
+            });
+            _manager.AddEventReceiver("C", (_, _) =>
+            {
+                var builder = new Mock<IMessageEventReceiverBuilder>();
+                builder.Setup(m => m.BuildReceiver(It.IsAny<string>()))
+                    .Returns(receiverC.Object);
+
+                return builder.Object;
+            });
+
+            _manager.Start();
+
+            // Act/Assert
+            Assert.Throws<AggregateException>(_manager.Stop);
+            _manager.Stop();
+
+            receiverA.Verify(m =>  m.Dispose(), Times.Once);
+            receiverB.Verify(m => m.Dispose(), Times.Once);
+            receiverC.Verify(m => m.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void Stop_MultipleCalls_RunsOnce_MultipleReceiversStop_NoExceptions_StopsAllReceiversSuccessfully()
+        {
+            // Arrange
+            var receiverA = new Mock<IMessageEventReceiver>();
+            var receiverB = new Mock<IMessageEventReceiver>();
+            var receiverC = new Mock<IMessageEventReceiver>();
+
+            _manager.AddEventReceiver("A", (_, _) =>
+            {
+                var builder = new Mock<IMessageEventReceiverBuilder>();
+                builder.Setup(m => m.BuildReceiver(It.IsAny<string>()))
+                    .Returns(receiverA.Object);
+
+                return builder.Object;
+            });
+            _manager.AddEventReceiver("B", (_, _) =>
+            {
+                var builder = new Mock<IMessageEventReceiverBuilder>();
+                builder.Setup(m => m.BuildReceiver(It.IsAny<string>()))
+                    .Returns(receiverB.Object);
+
+                return builder.Object;
+            });
+            _manager.AddEventReceiver("C", (_, _) =>
+            {
+                var builder = new Mock<IMessageEventReceiverBuilder>();
+                builder.Setup(m => m.BuildReceiver(It.IsAny<string>()))
+                    .Returns(receiverC.Object);
+
+                return builder.Object;
+            });
+
+            _manager.Start();
+
+            // Act
+            _manager.Stop();
+            _manager.Stop();
+
+            // Assert
+            receiverA.Verify(m => m.Dispose(), Times.Once);
+            receiverB.Verify(m => m.Dispose(), Times.Once);
+            receiverC.Verify(m => m.Dispose(), Times.Once);
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.MessageBus.UnitTests/Internal/Services/MessageEventSinkTests.cs
+++ b/src/OSK.MessageBus.UnitTests/Internal/Services/MessageEventSinkTests.cs
@@ -1,0 +1,70 @@
+﻿using Moq;
+using OSK.Functions.Outputs.Logging.Abstractions;
+using OSK.Functions.Outputs.Mocks;
+using OSK.MessageBus.Abstractions;
+using OSK.MessageBus.Ports;
+using OSK.MessageBus.UnitTests.Helpers;
+using System.Net;
+using Xunit;
+
+namespace OSK.MessageBus.RabbitMQ.UnitTests.Internal.Services
+{
+    public class MessageEventSinkTests
+    {
+        #region Variables
+
+        private readonly Mock<IMessageEventPublisher> _mockBus;
+        private readonly IOutputFactory<MessageEventSinkBase> _outputFactory;
+
+        private readonly IMessageEventSink _eventSink;
+
+        #endregion
+
+        #region Constructors
+
+        public MessageEventSinkTests()
+        {
+            _mockBus = new Mock<IMessageEventPublisher>();
+            _outputFactory = new MockOutputFactory<MessageEventSinkBase>();
+             
+            _eventSink = new TestEventSink(_mockBus.Object, _outputFactory);
+        }
+
+        #endregion
+
+        #region PublishAsync
+
+        [Fact]
+        public async Task PublishAsync_PassThrough_ReturnsBusOutput()
+        {
+            // Arrange
+            _mockBus.Setup(m => m.PublishAsync(It.IsAny<TestEvent>(), It.IsAny<MessagePublishOptions>(),
+                It.IsAny<CancellationToken>()));
+
+            // Act
+            var result = await _eventSink.PublishAsync(new TestEvent());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, result.Code.StatusCode);
+        }
+
+        [Fact]
+        public async Task PublishAsync_ThrowsException_ReturnsOutputExceptionWithOriginationSource()
+        {
+            // Arrange
+            _mockBus.Setup(m => m.PublishAsync(It.IsAny<TestEvent>(), It.IsAny<MessagePublishOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException());
+
+            // Act
+            var result = await _eventSink.PublishAsync(new TestEvent());
+
+            // Assert
+            Assert.Equal(HttpStatusCode.InternalServerError, result.Code.StatusCode);
+            Assert.IsType<InvalidOperationException>(result.ErrorInformation!.Value.Exception);
+            Assert.Equal(TestEventSink.TestEventSinkSource, result.Code.OriginationSource);
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.MessageBus.UnitTests/OSK.MessageBus.UnitTests.csproj
+++ b/src/OSK.MessageBus.UnitTests/OSK.MessageBus.UnitTests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="OSK.Functions.Outputs.Mocks" Version="1.5.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\OSK.MessageBus\OSK.MessageBus.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.MessageBus.sln
+++ b/src/OSK.MessageBus.sln
@@ -1,0 +1,49 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35312.102
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.MessageBus.Abstractions", "OSK.MessageBus.Abstractions\OSK.MessageBus.Abstractions.csproj", "{BD47D1A7-9844-4F2D-829E-7A5C3A6AAF26}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.MessageBus", "OSK.MessageBus\OSK.MessageBus.csproj", "{8D38C3EE-CD3D-4A71-877B-763E929C25D9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.MessageBus.Events.Abstractions", "OSK.MessageBus.Events.Abstractions\OSK.MessageBus.Events.Abstractions.csproj", "{313058C3-0508-47D7-AEED-85379614532A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.MessageBus.Application", "OSK.MessageBus.Application\OSK.MessageBus.Application.csproj", "{959B0CDD-1CAD-46FA-AAEA-58A94F7EC222}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSK.MessageBus.UnitTests", "OSK.MessageBus.UnitTests\OSK.MessageBus.UnitTests.csproj", "{0AD36210-0F0F-407E-95F2-4E9D3A0E3D73}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BD47D1A7-9844-4F2D-829E-7A5C3A6AAF26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD47D1A7-9844-4F2D-829E-7A5C3A6AAF26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD47D1A7-9844-4F2D-829E-7A5C3A6AAF26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD47D1A7-9844-4F2D-829E-7A5C3A6AAF26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D38C3EE-CD3D-4A71-877B-763E929C25D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D38C3EE-CD3D-4A71-877B-763E929C25D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D38C3EE-CD3D-4A71-877B-763E929C25D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D38C3EE-CD3D-4A71-877B-763E929C25D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{313058C3-0508-47D7-AEED-85379614532A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{313058C3-0508-47D7-AEED-85379614532A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{313058C3-0508-47D7-AEED-85379614532A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{313058C3-0508-47D7-AEED-85379614532A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{959B0CDD-1CAD-46FA-AAEA-58A94F7EC222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{959B0CDD-1CAD-46FA-AAEA-58A94F7EC222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{959B0CDD-1CAD-46FA-AAEA-58A94F7EC222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{959B0CDD-1CAD-46FA-AAEA-58A94F7EC222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AD36210-0F0F-407E-95F2-4E9D3A0E3D73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AD36210-0F0F-407E-95F2-4E9D3A0E3D73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AD36210-0F0F-407E-95F2-4E9D3A0E3D73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AD36210-0F0F-407E-95F2-4E9D3A0E3D73}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {72623589-11C8-4DF8-846A-1B866789AD36}
+	EndGlobalSection
+EndGlobal

--- a/src/OSK.MessageBus/Exceptions/MessageBusException.cs
+++ b/src/OSK.MessageBus/Exceptions/MessageBusException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace OSK.MessageBus.Exceptions
+{
+    public class MessageBusException: Exception
+    {
+        public MessageBusException(string message) 
+            : base(message)
+        {
+        }
+
+        public MessageBusException(string message, Exception ex)
+            : base(message, ex)
+        {
+        }
+    }
+}

--- a/src/OSK.MessageBus/Exceptions/MessageBusPublishException.cs
+++ b/src/OSK.MessageBus/Exceptions/MessageBusPublishException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace OSK.MessageBus.Exceptions
+{
+    public class MessageBusPublishException: Exception
+    {
+        public MessageBusPublishException(string message)
+            : base(message)
+        {
+        }
+
+        public MessageBusPublishException(string message, Exception ex)
+            : base(message, ex)
+        {
+        }
+    }
+}

--- a/src/OSK.MessageBus/Exceptions/MessageBusReceiverException.cs
+++ b/src/OSK.MessageBus/Exceptions/MessageBusReceiverException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace OSK.MessageBus.Exceptions
+{
+    public class MessageBusReceiverException : Exception
+    {
+        public MessageBusReceiverException(string message)
+            : base(message)
+        {
+        }
+
+        public MessageBusReceiverException(string message, Exception ex)
+            : base(message, ex)
+        {
+        }
+    }
+}

--- a/src/OSK.MessageBus/Internal/Services/MessageEventContext.cs
+++ b/src/OSK.MessageBus/Internal/Services/MessageEventContext.cs
@@ -1,0 +1,22 @@
+﻿using OSK.MessageBus.Abstractions;
+using OSK.MessageBus.Events.Abstractions;
+using System;
+
+namespace OSK.MessageBus.Internal.Services
+{
+    public class MessageEventContext<TMessage>(IServiceProvider services, TMessage message, object? rawMessage): IMessageEventContext<TMessage>
+        where TMessage: IMessageEvent
+    {
+        #region Variables
+
+        public object? RawMessage => rawMessage;
+
+        public IServiceProvider Services => services;
+
+        public IMessageEvent Message => message;
+
+        TMessage IMessageEventContext<TMessage>.Message => message;
+
+        #endregion
+    }
+}

--- a/src/OSK.MessageBus/Internal/Services/MessageEventReceiverManager.cs
+++ b/src/OSK.MessageBus/Internal/Services/MessageEventReceiverManager.cs
@@ -1,0 +1,107 @@
+﻿using OSK.MessageBus.Ports;
+using System;
+using System.Collections.Generic;
+
+namespace OSK.MessageBus.Internal.Services
+{
+    internal class MessageEventReceiverManager(IServiceProvider serviceProvider) : IMessageEventReceiverManager
+    {
+        #region Variables
+
+        private readonly Dictionary<string, Func<IServiceProvider, IEnumerable<Action<IMessageEventReceiverBuilder>>, IMessageEventReceiverBuilder>> _builderFactories = new();
+        private readonly List<Action<IMessageEventReceiverBuilder>> _globalConfigurators = new();
+        private List<IMessageEventReceiver> _receivers = new();
+        private bool _started;
+
+        #endregion
+
+        #region IMessageEventReceiverManager
+
+        public IMessageEventReceiverManager AddConfigurator(Action<IMessageEventReceiverBuilder> configurator)
+        {
+            if (configurator == null)
+            {
+                throw new ArgumentNullException(nameof(configurator));
+            }
+
+            _globalConfigurators.Add(configurator);
+            return this;
+        }
+
+        public IMessageEventReceiverManager AddEventReceiver(string subscriptionId,
+            Func<IServiceProvider, IEnumerable<Action<IMessageEventReceiverBuilder>>, IMessageEventReceiverBuilder> factory)
+        {
+            if (string.IsNullOrWhiteSpace(subscriptionId))
+            {
+                throw new ArgumentException("Subscription id can not be empty.", nameof(subscriptionId));
+            }
+            if (_builderFactories.TryGetValue(subscriptionId, out _))
+            {
+                throw new InvalidOperationException($"Subcription id, {subscriptionId}, has already been added.");
+            }
+            if (factory == null)
+            {
+                throw new ArgumentNullException("Factory can not be null.", nameof(factory));
+            }
+
+            _builderFactories[subscriptionId] = factory;
+            return this;
+        }
+
+        public void Start()
+        {
+            if (_started)
+            {
+                return;
+            }
+
+            _receivers = new List<IMessageEventReceiver>();
+            foreach (var buildFactory in _builderFactories)
+            {
+                var eventReceiverBuilder = buildFactory.Value(serviceProvider, _globalConfigurators);
+                var receiver = eventReceiverBuilder.BuildReceiver(buildFactory.Key);
+                receiver.Start();
+
+                _receivers.Add(receiver);
+            }
+
+            _started = true;
+        }
+
+        public void Stop()
+        {
+            if (!_started)
+            {
+                return;
+            }
+
+            var exceptions = new List<Exception>();
+            foreach (var receiver in _receivers)
+            {
+                try
+                {
+                    receiver.Dispose();
+                }
+                catch(Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+
+            _receivers.Clear();
+            _started = false;
+
+            if (exceptions.Count > 0)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
+        public void Dispose()
+        {
+            Stop();
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.MessageBus/MessageEventReceiverBase.cs
+++ b/src/OSK.MessageBus/MessageEventReceiverBase.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using OSK.MessageBus.Events.Abstractions;
+using OSK.MessageBus.Internal.Services;
+using OSK.MessageBus.Models;
+using OSK.MessageBus.Ports;
+using System;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus
+{
+    public abstract class MessageEventReceiverBase(MessageEventDelegate eventDelegate, IServiceProvider serviceProvider) 
+        : IMessageEventReceiver
+    {
+        public abstract void Dispose();
+        public abstract void Start();
+
+        protected async Task HandleEventAsync<T>(T message, object? rawMessageEvent)
+            where T : IMessageEvent
+        {
+            using var scope = serviceProvider.CreateScope();
+            var context = new MessageEventContext<T>(scope.ServiceProvider, message, rawMessageEvent);
+            await eventDelegate(context);
+        }
+    }
+}

--- a/src/OSK.MessageBus/MessageEventReceiverBuilderBase.cs
+++ b/src/OSK.MessageBus/MessageEventReceiverBuilderBase.cs
@@ -1,0 +1,60 @@
+﻿using OSK.MessageBus.Models;
+using OSK.MessageBus.Ports;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OSK.MessageBus
+{
+    public abstract class MessageEventReceiverBuilderBase : IMessageEventReceiverBuilder
+    {
+        #region Variables
+
+        private const string UnhandledEventMessage = "No event handlers were registered and the event could not be processed.";
+
+        private readonly List<Func<MessageEventDelegate, MessageEventDelegate>> _middlewares = new();
+
+        #endregion
+
+        #region IMessageEventReceiverBuilder
+
+        public IMessageEventReceiverBuilder Use(Func<MessageEventDelegate, MessageEventDelegate> middleware)
+        {
+            if (middleware == null)
+            {
+                throw new ArgumentNullException("Middleware can not be null.", nameof(middleware));
+            }
+
+            _middlewares.Add(middleware);
+            return this;
+        }
+
+        public IMessageEventReceiver BuildReceiver(string subscriptionId)
+        {
+            return BuildReceiver(subscriptionId, BuildMessageEventDelegate());
+        }
+
+        #endregion
+
+        #region Helpers
+
+        protected abstract IMessageEventReceiver BuildReceiver(string subscriptionId, MessageEventDelegate eventDelegate);
+
+        private MessageEventDelegate BuildMessageEventDelegate()
+        {
+            if (_middlewares.Count == 0)
+            {
+                throw new InvalidOperationException(UnhandledEventMessage);
+            }
+
+            MessageEventDelegate eventDelegate = static _ =>
+            {
+                throw new InvalidOperationException(UnhandledEventMessage);
+            };
+            return Enumerable.Reverse(_middlewares)
+                             .Aggregate(eventDelegate, (aggregatedDelegate, middleware) => middleware(aggregatedDelegate));
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.MessageBus/MessageEventReceiverBuilderExtensions.cs
+++ b/src/OSK.MessageBus/MessageEventReceiverBuilderExtensions.cs
@@ -1,0 +1,183 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using OSK.MessageBus.Abstractions;
+using OSK.MessageBus.Events.Abstractions;
+using OSK.MessageBus.Models;
+using OSK.MessageBus.Ports;
+using System;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus
+{
+    public static class MessageEventReceiverBuilderExtensions
+    {
+        #region Handlers
+
+        public static IMessageEventReceiverBuilder UseHandler(this IMessageEventReceiverBuilder builder,
+            IMessageEventHandler handler)
+        {
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            return builder.UseHandler(handler.HandleEventAsync);
+        }
+
+        public static IMessageEventReceiverBuilder UseHandler(this IMessageEventReceiverBuilder builder,
+            Func<IMessageEventContext, Task> handlerFunc)
+        {
+            if (handlerFunc == null)
+            {
+                throw new ArgumentNullException(nameof(handlerFunc));
+            }
+
+            builder.Use(_ => context => handlerFunc(context));
+            return builder;
+        }
+
+        public static IMessageEventReceiverBuilder UseHandler<THandler>(this IMessageEventReceiverBuilder builder)
+            where THandler : IMessageEventHandler
+        {
+            return builder.Use(_ => context =>
+            {
+                var handler = context.Services.GetRequiredService<THandler>();
+                return handler.HandleEventAsync(context);
+            });
+        }
+
+        public static IMessageEventReceiverBuilder UseHandler<TEvent, THandler>(this IMessageEventReceiverBuilder builder,
+            THandler handler)
+            where TEvent : IMessageEvent
+            where THandler : IMessageEventHandler<TEvent>
+        {
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            return builder.UseHandler<TEvent>(handler.HandleEventAsync);
+        }
+
+        public static IMessageEventReceiverBuilder UseHandler<TEvent>(this IMessageEventReceiverBuilder builder,
+            Func<IMessageEventContext<TEvent>, Task> handleFunc)
+            where TEvent : IMessageEvent
+        {
+            if (handleFunc == null)
+            {
+                throw new ArgumentNullException(nameof(handleFunc));
+            }
+
+            return builder.Use(next => context =>
+            {
+                if (context is IMessageEventContext<TEvent> typedContext)
+                {
+                    return handleFunc(typedContext);
+                }
+
+                return next(context);
+            });
+        }
+
+        public static IMessageEventReceiverBuilder UseHandler<TEvent, THandler>(this IMessageEventReceiverBuilder builder)
+            where TEvent : IMessageEvent
+            where THandler : IMessageEventHandler<TEvent>
+        {
+            return builder.Use(next => context =>
+            {
+                if (context is IMessageEventContext<TEvent> typedContext)
+                {
+                    var handler = context.Services.GetRequiredService<THandler>();
+                    return handler.HandleEventAsync(typedContext);
+                }
+
+                return next(context);
+            });
+        }
+
+        #endregion
+
+        #region Middleware
+
+        public static IMessageEventReceiverBuilder UseMiddleware(this IMessageEventReceiverBuilder builder,
+            IMessageEventMiddleware middleware)
+        {
+            if (middleware == null)
+            {
+                throw new ArgumentNullException(nameof(middleware));
+            }
+
+            return builder.UseMiddleware(middleware.InvokeAsync);
+        }
+
+        public static IMessageEventReceiverBuilder UseMiddleware(this IMessageEventReceiverBuilder builder,
+            Func<IMessageEventContext, MessageEventDelegate, Task> middlewareFunc)
+        {
+            if (middlewareFunc == null)
+            {
+                throw new ArgumentNullException(nameof(middlewareFunc));
+            }
+
+            return builder.Use(next => context => middlewareFunc(context, next));
+        }
+
+        public static IMessageEventReceiverBuilder UseMiddleware<TMiddleware>(this IMessageEventReceiverBuilder builder)
+            where TMiddleware : IMessageEventMiddleware
+        {
+            return builder.Use(next => context =>
+            {
+                var middleware = context.Services.GetRequiredService<TMiddleware>();
+                return middleware.InvokeAsync(context, next);
+            });
+        }
+
+        public static IMessageEventReceiverBuilder UseMiddleware<TEvent>(this IMessageEventReceiverBuilder builder,
+            IMessageEventMiddleware<TEvent> middleware)
+            where TEvent : IMessageEvent
+        {
+            if (middleware == null)
+            {
+                throw new ArgumentNullException(nameof(middleware));
+            }
+
+            return builder.UseMiddleware<TEvent>(middleware.InvokeAsync);
+        }
+
+        public static IMessageEventReceiverBuilder UseMiddleware<TEvent>(this IMessageEventReceiverBuilder builder,
+            Func<IMessageEventContext<TEvent>, MessageEventDelegate, Task> middlewareFunc)
+            where TEvent : IMessageEvent
+        {
+            if (middlewareFunc == null)
+            {
+                throw new ArgumentNullException(nameof(middlewareFunc));
+            }
+
+            return builder.Use(next => context =>
+            {
+                if (context is IMessageEventContext<TEvent> typedContext)
+                {
+                    return middlewareFunc(typedContext, next);
+                }
+
+                return next(context);
+            });
+        }
+
+        public static IMessageEventReceiverBuilder UseMiddleware<TEvent, TMiddleware>(this IMessageEventReceiverBuilder builder)
+            where TEvent : IMessageEvent
+            where TMiddleware : IMessageEventMiddleware<TEvent>
+        {
+            return builder.Use(next => context =>
+            {
+                if (context is IMessageEventContext<TEvent> typedContext)
+                {
+                    var middleware = context.Services.GetRequiredService<TMiddleware>();
+                    return middleware.InvokeAsync(typedContext, next);
+                }
+
+                return next(context);
+            });
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.MessageBus/MessageEventSinkBase.cs
+++ b/src/OSK.MessageBus/MessageEventSinkBase.cs
@@ -1,0 +1,34 @@
+﻿using OSK.Functions.Outputs.Abstractions;
+using OSK.Functions.Outputs.Logging.Abstractions;
+using OSK.MessageBus.Abstractions;
+using OSK.MessageBus.Events.Abstractions;
+using OSK.MessageBus.Ports;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus
+{
+    public abstract class MessageEventSinkBase(IMessageEventPublisher publisher,
+        IOutputFactory<MessageEventSinkBase> outputFactory, string orginationSource)
+        : IMessageEventSink
+    {
+        #region IMessageEventSink
+
+        public async Task<IOutput> PublishAsync<TMessage>(TMessage messageEvent, MessagePublishOptions options, CancellationToken cancellationToken = default)
+            where TMessage : IMessageEvent
+        {
+            try
+            {
+                await publisher.PublishAsync(messageEvent, options, cancellationToken);
+                return outputFactory.Success();
+            }
+            catch (Exception ex)
+            {
+                return outputFactory.Exception(ex, orginationSource);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.MessageBus/Models/MessageEventDelegate.cs
+++ b/src/OSK.MessageBus/Models/MessageEventDelegate.cs
@@ -1,0 +1,7 @@
+﻿using OSK.MessageBus.Abstractions;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus.Models
+{
+    public delegate Task MessageEventDelegate(IMessageEventContext messageEventContext);
+}

--- a/src/OSK.MessageBus/OSK.MessageBus.csproj
+++ b/src/OSK.MessageBus/OSK.MessageBus.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<Nullable>enable</Nullable>
+		<LangVersion>12</LangVersion>
+		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.MessageBus</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<Description>A generic implementation layer for communicating across a variety of different message buses seamlessly and easily. Meant to allow easy integration between different message buses without causing drastic changes to the consumers.</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, Communication, Message, Bus, Architecture, Async, Event, Consistency, Network, Api</PackageTags>
+		<Authors>BlankDev117</Authors>
+		<Title>OSK.MessageBus</Title>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+		<PackageReference Include="OSK.Hexagonal.MetaData" Version="0.0.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\OSK.MessageBus.Abstractions\OSK.MessageBus.Abstractions.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.MessageBus/Ports/IMessageEventHandler.cs
+++ b/src/OSK.MessageBus/Ports/IMessageEventHandler.cs
@@ -1,0 +1,10 @@
+﻿using OSK.MessageBus.Abstractions;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus.Ports
+{
+    public interface IMessageEventHandler
+    {
+        Task HandleEventAsync(IMessageEventContext context);
+    }
+}

--- a/src/OSK.MessageBus/Ports/IMessageEventHandler`1.cs
+++ b/src/OSK.MessageBus/Ports/IMessageEventHandler`1.cs
@@ -1,0 +1,12 @@
+﻿using OSK.MessageBus.Abstractions;
+using OSK.MessageBus.Events.Abstractions;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus.Ports
+{
+    public interface IMessageEventHandler<TMessage>
+        where TMessage: IMessageEvent
+    {
+        Task HandleEventAsync(IMessageEventContext<TMessage> context);
+    }
+}

--- a/src/OSK.MessageBus/Ports/IMessageEventMiddleware.cs
+++ b/src/OSK.MessageBus/Ports/IMessageEventMiddleware.cs
@@ -1,0 +1,11 @@
+﻿using OSK.MessageBus.Abstractions;
+using OSK.MessageBus.Models;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus.Ports
+{
+    public interface IMessageEventMiddleware
+    {
+        Task InvokeAsync(IMessageEventContext context, MessageEventDelegate next);
+    }
+}

--- a/src/OSK.MessageBus/Ports/IMessageEventMiddleware`1.cs
+++ b/src/OSK.MessageBus/Ports/IMessageEventMiddleware`1.cs
@@ -1,0 +1,13 @@
+﻿using OSK.MessageBus.Abstractions;
+using OSK.MessageBus.Events.Abstractions;
+using OSK.MessageBus.Models;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus.Ports
+{
+    public interface IMessageEventMiddleware<TEvent>
+        where TEvent: IMessageEvent
+    {
+        Task InvokeAsync(IMessageEventContext<TEvent> context, MessageEventDelegate next);
+    }
+}

--- a/src/OSK.MessageBus/Ports/IMessageEventPublisher.cs
+++ b/src/OSK.MessageBus/Ports/IMessageEventPublisher.cs
@@ -1,0 +1,16 @@
+﻿using OSK.Hexagonal.MetaData;
+using OSK.MessageBus.Abstractions;
+using OSK.MessageBus.Events.Abstractions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSK.MessageBus.Ports
+{
+    [HexagonalPort(HexagonalPort.Primary)]
+    public interface IMessageEventPublisher
+    {
+        Task PublishAsync<TMessage>(TMessage message, MessagePublishOptions options, 
+            CancellationToken cancellationToken = default)
+            where TMessage: IMessageEvent;
+    }
+}

--- a/src/OSK.MessageBus/Ports/IMessageEventReceiver.cs
+++ b/src/OSK.MessageBus/Ports/IMessageEventReceiver.cs
@@ -1,0 +1,11 @@
+﻿using OSK.Hexagonal.MetaData;
+using System;
+
+namespace OSK.MessageBus.Ports
+{
+    [HexagonalPort(HexagonalPort.Primary)]
+    public interface IMessageEventReceiver: IDisposable
+    {
+        void Start();
+    }
+}

--- a/src/OSK.MessageBus/Ports/IMessageEventReceiverBuilder.cs
+++ b/src/OSK.MessageBus/Ports/IMessageEventReceiverBuilder.cs
@@ -1,0 +1,14 @@
+﻿using OSK.Hexagonal.MetaData;
+using OSK.MessageBus.Models;
+using System;
+
+namespace OSK.MessageBus.Ports
+{
+    [HexagonalPort(HexagonalPort.Primary)]
+    public interface IMessageEventReceiverBuilder
+    {
+        IMessageEventReceiverBuilder Use(Func<MessageEventDelegate, MessageEventDelegate> middleware);
+
+        IMessageEventReceiver BuildReceiver(string subscriptionId);
+    }
+}

--- a/src/OSK.MessageBus/Ports/IMessageEventReceiverConfigurator.cs
+++ b/src/OSK.MessageBus/Ports/IMessageEventReceiverConfigurator.cs
@@ -1,0 +1,10 @@
+﻿using OSK.Hexagonal.MetaData;
+
+namespace OSK.MessageBus.Ports
+{
+    [HexagonalPort(HexagonalPort.Secondary)]
+    public interface IMessageEventReceiverConfigurator
+    {
+        void ConfigureReceivers(IMessageEventReceiverManager manager);
+    }
+}

--- a/src/OSK.MessageBus/Ports/IMessageEventReceiverManager.cs
+++ b/src/OSK.MessageBus/Ports/IMessageEventReceiverManager.cs
@@ -1,0 +1,19 @@
+﻿using OSK.Hexagonal.MetaData;
+using System;
+using System.Collections.Generic;
+
+namespace OSK.MessageBus.Ports
+{
+    [HexagonalPort(HexagonalPort.Primary)]
+    public interface IMessageEventReceiverManager: IDisposable
+    {
+        IMessageEventReceiverManager AddConfigurator(Action<IMessageEventReceiverBuilder> configurator);
+
+        IMessageEventReceiverManager AddEventReceiver(string subscriptionId,
+            Func<IServiceProvider, IEnumerable<Action<IMessageEventReceiverBuilder>>, IMessageEventReceiverBuilder> factory);
+
+        void Start();
+
+        void Stop();
+    }
+}

--- a/src/OSK.MessageBus/Properties/Assembly.cs
+++ b/src/OSK.MessageBus/Properties/Assembly.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("OSK.MessageBus.UnitTests")]

--- a/src/OSK.MessageBus/ServiceCollectionExtensions.cs
+++ b/src/OSK.MessageBus/ServiceCollectionExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OSK.MessageBus.Abstractions;
+using OSK.MessageBus.Internal.Services;
+using OSK.MessageBus.Ports;
+
+namespace OSK.MessageBus
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddMessageBus(this IServiceCollection services)
+        {
+            services.TryAddTransient<IMessageEventReceiverManager, MessageEventReceiverManager>();
+            services.TryAddTransient<IMessageEventSink, MessageEventSinkBase>();
+
+            return services;
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----
Having a generic abstraction layer that can be easily integrated with a variety of message buses is a beneficial tool

Modifications
----
* Addeded initial project:
  * B/L MessageBus
  * Event Abstractions
  * B/L Abstractions
  * Application
  * UnitTests

Result
----
A basic abstraction layer to create message bus implementations is available

Fixes #1